### PR TITLE
Fixing typos and mistakes

### DIFF
--- a/content/exercises/sat/index.md
+++ b/content/exercises/sat/index.md
@@ -57,7 +57,7 @@ $$(\mathsf{RAIN}\land \mathsf{SUN}\land \neg\mathsf{SUN})\lor
 
 ## d) 
 
-$$\neg(\mathsf{RAIN}\lor (\mathsf{SUN}\lor \neg\mathsf{SUN})\land
+$$\neg(\mathsf{RAIN}\lor (\mathsf{SUN}\lor \neg\mathsf{SUN}))\land
 \neg((\neg\mathsf{RAIN}\lor \neg\mathsf{SUN})\lor \mathsf{SUN})$$
 
 {{< latex >}}

--- a/content/exercises/valid-inference/index.md
+++ b/content/exercises/valid-inference/index.md
@@ -120,7 +120,10 @@ No. That contradicts the definition of validity.
 
 **d)**
 
-Yes. For example, any strong, statistical reasoning.
+No. If an inference preserves truth always, then it preserves truth most of the
+time. You can illustrate with standard 'definitional' rules for the logical
+connectives, which are easily seen to be inductively valid. $A\land B\vDash A$
+and $A\vDash A\lor B$ etc.
 
 **e)** z Yes. Take any strong conditional probability with a false condition.
 The moon is made of cheese, so its probably delicious.
@@ -135,10 +138,8 @@ Yes. Because inductive validity is not necessary.
 
 **h)**
 
-No. If an inference preserves truth always, then it preserves truth most of the
-time. You can illustrate with standard 'definitional' rules for the logical
-connectives, which are easily seen to be inductively valid. $A\land B\vDash A$
-and $A\vDash A\lor B$ etc.
+Yes. For example, any strong, statistical reasoning.
+
 
 # Semantic tools {.solved}
 

--- a/content/textbook/formal-languages/index.md
+++ b/content/textbook/formal-languages/index.md
@@ -129,7 +129,7 @@ supreme.
 
 Before we can go ahead and give the mathematical definition of what a formal
 language is, we need to talk a bit more about _sets_. Formal languages _are_
-sets. so we need to know whats are set is before we can talk about formal
+sets. So, we need to know what a set is before we can talk about formal
 languages.
 
 In {{< chapter_ref chapter="valid-inference" id="semantic-methods-for-deduction" >}}
@@ -341,7 +341,7 @@ Here's how this works for a standard language in propositional logic, where $\Si
 
 We then say that: 
 
-+ $p,\dots, p_n \in \mathcal{L}$ and
++ $p_1,\dots, p_n \in \mathcal{L}$ and
 
 + if $A\in\mathcal{L}$, then $\neg A\in \mathcal{L}$ as well as
 

--- a/content/textbook/valid-inference/index.md
+++ b/content/textbook/valid-inference/index.md
@@ -468,14 +468,14 @@ _Sketch of an Explanation_: Assuming that $A \vDash B$ and $A
 any model $\mathcal{M}$ is in $[A]$, the same  model $\mathcal{M}$
 also has to be in $[B]\cap[C]$. We have $[A]\subseteq[B]\cap[C]$.
 
-+ If $A \vDash B$, then $A\land B \vDash C$
++ If $A \vDash C$, then $A\land B \vDash C$
 
 This principle says that if it is valid to infer a conclusion from some
 premises, then it is valid to infer the exact same conclusion after 'adding new
 information' to those premises.
 
 _Sketch of an Explanation_: We showed that $A\land B \vDash A$. So if we
-asume $A \vDash B$ then we have both $[A\land B]\subseteq[A]$ and
+asume $A \vDash C$ then we have both $[A\land B]\subseteq[A]$ and
 $[A]\subseteq[C]$. This implies $[A\land B]\subseteq[C]$ because the
 subset relation is **transitive**: if first set is part of second, and second
 set is part of third, the first one has to be part of the third.


### PR DESCRIPTION
textbook:
- chapter 2: monotonicity explanation fixed
- chapter 3: fixed typo, missing 1 in $p_1$ 

exercises:
- set 2: answers 4d and 4h are swapped, d should be no and h should be yes
- set 5: missing closing bracket added